### PR TITLE
fix rounding issue #13

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: lazyraster
-Version: 0.5.0.9002
+Version: 0.5.0.9003
 Title: Generate Raster Data Lazily from 'GDAL' 
 Description: Read raster data at a specified resolution on-demand via 'GDAL' 
  (the Geospatial Data Abstraction Library <https://gdal.org/>). Augments the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # lazyraster dev
 
+* Avoid issue of non-integer dimensions, with different rounding schemes #13. 
+
 * Added window dimension to lazyraster print out (boilerplate for no crop). 
 
 # lazyraster 0.5.0

--- a/R/lazyraster.R
+++ b/R/lazyraster.R
@@ -66,6 +66,9 @@ lazyraster <- function(gdalsource, band = 1, sds = NULL, ...) {
 #' Control the dimensions and method for resampling with the 'dim' and
 #' 'resample' arguments.
 #'
+#' If `dim` is non-integer it is rounded according to what raster does with the
+#' dimensions.
+#'
 #' When `native = TRUE` the `dim` argument is ignored, and no resampling is performed.
 #' @param x a [lazyraster]
 #' @param dim dimensions, pixel size in rows and columns
@@ -143,6 +146,10 @@ pull_lazyraster <- function(x, pulldim = NULL, resample = "NearestNeighbour", na
 
   ## TODO raster from ssraster, override with dim
   r <- lazy_to_raster(x, dim = pulldim)
+  ## GDAL rounds down, but raster has already rounded up (snap = out)
+  ## so we should derive the pulldim from the raster
+  pulldim <- dim(r)[c(2L, 1L)]  ##https://github.com/hypertidy/lazyraster/issues/13
+
   ## TODO pull window spec from info/plotdim, allow choice of resampling
   window_odim <- c(0, 0, x$info$dimXY[1], x$info$dimXY[2]) ## the global window
   if (!is.null(x$window$window)) {

--- a/man/as_raster.Rd
+++ b/man/as_raster.Rd
@@ -27,5 +27,8 @@ contract and demanding pixel values at a given resolution.
 Control the dimensions and method for resampling with the 'dim' and
 'resample' arguments.
 
+If \code{dim} is non-integer it is rounded according to what raster does with the
+dimensions.
+
 When \code{native = TRUE} the \code{dim} argument is ignored, and no resampling is performed.
 }


### PR DESCRIPTION
with non-integer dim (especially on .5) there were different dimensions inferred by raster and GDAL. This applies the raster scheme

Fixes #13 
